### PR TITLE
Remove debug operations

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,8 +7,7 @@
 
 %% Compiler Options ============================================================
 {erl_opts,
- [debug_info,
-  warnings_as_errors]}.
+ [debug_info]}.
 
 %% EUnit =======================================================================
 {eunit_opts, [verbose,

--- a/src/ecrn_agent.erl
+++ b/src/ecrn_agent.erl
@@ -191,7 +191,6 @@ normalize_seconds(State, Seconds) ->
         Value when Value >= 0 ->
             Value;
         _ ->
-            erlang:display(erlang:get_stacktrace()),
             throw(invalid_once_exception)
     end.
 


### PR DESCRIPTION
`erlang:get_stacktrace` is deprecated in OTP 21, and will fail the build when compiled with `warnings_as_errors`.